### PR TITLE
Updated northwind-data.cypher to include AzureOpenAI

### DIFF
--- a/load-data/northwind-data-azureopenai.cypher
+++ b/load-data/northwind-data-azureopenai.cypher
@@ -1,0 +1,98 @@
+//THIS FILE IS FOR WHEN YOU ARE USING AZURE OPENAI ENDPOINT:
+
+// Provide the endpoint details
+:param provider => 'AzureOpenAI';
+:param openAIKey => "<your Azure OpenAI API Key>";
+:param resource => "<your Azure OpenAI resource name">;
+:param deployment => "<your Azure OpenAI embedding model deployment name>"
+
+/////////////////////////////////////////////////////////
+// Load Northwind Data
+/////////////////////////////////////////////////////////
+CREATE CONSTRAINT Product_productID IF NOT EXISTS FOR (p:Product) REQUIRE (p.productID) IS UNIQUE;
+CREATE CONSTRAINT Category_categoryID IF NOT EXISTS FOR (c:Category) REQUIRE (c.categoryID) IS UNIQUE;
+CREATE CONSTRAINT Supplier_supplierID IF NOT EXISTS FOR (s:Supplier) REQUIRE (s.supplierID) IS UNIQUE;
+CREATE CONSTRAINT Customer_customerID IF NOT EXISTS FOR (c:Customer) REQUIRE (c.customerID) IS UNIQUE;
+CREATE CONSTRAINT Order_orderID IF NOT EXISTS FOR (o:Order) REQUIRE (o.orderID) IS UNIQUE;
+CREATE CONSTRAINT Address_addressID IF NOT EXISTS FOR (a:Address) REQUIRE (a.addressID) IS UNIQUE;
+
+LOAD CSV WITH HEADERS FROM "https://data.neo4j.com/northwind/products.csv" AS row
+MERGE (n:Product {productID:row.productID})
+SET n += row,
+n.unitPrice = toFloat(row.unitPrice),
+n.unitsInStock = toInteger(row.unitsInStock), n.unitsOnOrder = toInteger(row.unitsOnOrder),
+n.reorderLevel = toInteger(row.reorderLevel), n.discontinued = (row.discontinued <> "0");
+
+LOAD CSV WITH HEADERS FROM "https://data.neo4j.com/northwind/categories.csv" AS row
+MERGE (n:Category {categoryID:row.categoryID})
+SET n += row;
+
+LOAD CSV WITH HEADERS FROM "https://data.neo4j.com/northwind/suppliers.csv" AS row
+MERGE (n:Supplier {supplierID:row.supplierID})
+SET n += row;
+
+MATCH (p:Product),(c:Category)
+WHERE p.categoryID = c.categoryID
+MERGE (p)-[:BELONGS_TO]->(c);
+
+MATCH (p:Product),(s:Supplier)
+WHERE p.supplierID = s.supplierID
+MERGE (s)<-[:SUPPLIED_BY]-(p);
+
+LOAD CSV WITH HEADERS FROM "https://data.neo4j.com/northwind/customers.csv" AS row
+MERGE (n:Customer {customerID:row.customerID})
+SET n += row;
+
+LOAD CSV WITH HEADERS FROM "https://data.neo4j.com/northwind/orders.csv" AS row
+MERGE (o:Order {orderID:row.orderID})
+SET o.customerID = row.customerID,
+    o.employeeID = row.employeeID,
+    o.orderDate = row.orderDate,
+    o.requiredDate = row.requiredDate,
+    o.shippedDate = row.shippedDate,
+    o.shipVia = row.shipVia,
+    o.freight = row.freight
+MERGE (a:Address {addressID: apoc.text.join([coalesce(row.shipName, ''), coalesce(row.shipAddress, ''),
+    coalesce(row.shipCity, ''), coalesce(row.shipRegion, ''), coalesce(row.shipPostalCode, ''),
+    coalesce(row.shipCountry, '')], ', ')})
+SET a.name = row.shipName,
+    a.address = row.shipAddress,
+    a.city = row.shipCity,
+    a.region = row.shipRegion,
+    a.postalCode = row.shipPostalCode,
+    a.country = row.shipCountry
+MERGE (o)-[:SHIPPED_TO]->(a)
+
+WITH o
+MATCH (c:Customer)
+WHERE c.customerID = o.customerID
+MERGE (c)-[:ORDERED]->(o);
+
+LOAD CSV WITH HEADERS FROM "https://data.neo4j.com/northwind/order-details.csv" AS row
+MATCH (p:Product), (o:Order)
+WHERE p.productID = row.productID AND o.orderID = row.orderID
+MERGE (o)-[details:ORDER_CONTAINS]->(p)
+SET details = row,
+details.quantity = toInteger(row.quantity);
+
+/////////////////////////////////////////////////////////
+// Set Text Property and Vector Index
+/////////////////////////////////////////////////////////
+//create text and embedding vector properties
+
+MATCH(p:Product)-[:BELONGS_TO]-(c:Category)
+SET p.text = "Product Category: " + c.categoryName + ' - ' + c.description + "\nProduct Name: " + p.productName
+WITH p, genai.vector.encode(p.text, token: $provider, {$openAIKey, resource: $resource, deployment: $deployment}) AS textEmbedding
+CALL db.create.setNodeVectorProperty(p,'textEmbedding', textEmbedding)
+RETURN p.productID, p.text, p.textEmbedding;
+
+//create vector index
+CREATE VECTOR INDEX product_text_embeddings
+FOR (n:Product) ON (n.textEmbedding)
+OPTIONS {indexConfig: {
+ `vector.dimensions`: 1536,
+ `vector.similarity_function`: 'cosine'
+}};
+
+//await index coming online
+CALL db.awaitIndex("product_text_embeddings", 300);

--- a/load-data/northwind-data-azureopenai.cypher
+++ b/load-data/northwind-data-azureopenai.cypher
@@ -1,6 +1,6 @@
 //THIS FILE IS FOR WHEN YOU ARE USING AZURE OPENAI ENDPOINT:
 
-// Provide the endpoint details
+// set azure openai api key for text embedding - REPLACE WITH YOUR OWN
 :param provider => 'AzureOpenAI';
 :param openAIKey => "<your Azure OpenAI API Key>";
 :param resource => "<your Azure OpenAI resource name">;

--- a/load-data/northwind-data.cypher
+++ b/load-data/northwind-data.cypher
@@ -1,5 +1,13 @@
+//IF YOU ARE USING OpenAI API:
 //set openai api key for text embedding - REPLACE WITH YOUR OWN
+:param provider => 'OpenAI';
 :param openAIKey => "<your OpenAI API Key>";
+
+//IF YOU ARE USING AzureOpenAI API:
+:param provider => 'AzureOpenAI';
+:param openAIKey => "<your Azure OpenAI API Key>";
+:param resource => "<your Azure OpenAI resource name">;
+:param deployment => "<your Azure OpenAI embedding model deployment name>"
 
 /////////////////////////////////////////////////////////
 // Load Northwind Data
@@ -74,11 +82,21 @@ details.quantity = toInteger(row.quantity);
 // Set Text Property and Vector Index
 /////////////////////////////////////////////////////////
 //create text and embedding vector properties
+// IF USING OpenAI
 MATCH(p:Product)-[:BELONGS_TO]-(c:Category)
 SET p.text = "Product Category: " + c.categoryName + ' - ' + c.description + "\nProduct Name: " + p.productName
 WITH p, genai.vector.encode(p.text, 'OpenAI', {token:$openAIKey}) AS textEmbedding
 CALL db.create.setNodeVectorProperty(p,'textEmbedding', textEmbedding)
 RETURN p.productID, p.text, p.textEmbedding;
+//
+
+// IF USING AzureOpenAI
+MATCH(p:Product)-[:BELONGS_TO]-(c:Category)
+SET p.text = "Product Category: " + c.categoryName + ' - ' + c.description + "\nProduct Name: " + p.productName
+WITH p, genai.vector.encode(p.text, token: $provider, {$openAIKey, resource: $resource, deployment: $deployment}) AS textEmbedding
+CALL db.create.setNodeVectorProperty(p,'textEmbedding', textEmbedding)
+RETURN p.productID, p.text, p.textEmbedding;
+//
 
 //create vector index
 CREATE VECTOR INDEX product_text_embeddings

--- a/load-data/northwind-data.cypher
+++ b/load-data/northwind-data.cypher
@@ -1,13 +1,9 @@
-//IF YOU ARE USING OpenAI API:
+//THIS FILE IS FOR WHEN YOU ARE USING OPENAI API DIRECTLY:
+
 //set openai api key for text embedding - REPLACE WITH YOUR OWN
 :param provider => 'OpenAI';
 :param openAIKey => "<your OpenAI API Key>";
 
-//IF YOU ARE USING AzureOpenAI API:
-:param provider => 'AzureOpenAI';
-:param openAIKey => "<your Azure OpenAI API Key>";
-:param resource => "<your Azure OpenAI resource name">;
-:param deployment => "<your Azure OpenAI embedding model deployment name>"
 
 /////////////////////////////////////////////////////////
 // Load Northwind Data
@@ -82,21 +78,12 @@ details.quantity = toInteger(row.quantity);
 // Set Text Property and Vector Index
 /////////////////////////////////////////////////////////
 //create text and embedding vector properties
-// IF USING OpenAI
+
 MATCH(p:Product)-[:BELONGS_TO]-(c:Category)
 SET p.text = "Product Category: " + c.categoryName + ' - ' + c.description + "\nProduct Name: " + p.productName
 WITH p, genai.vector.encode(p.text, 'OpenAI', {token:$openAIKey}) AS textEmbedding
 CALL db.create.setNodeVectorProperty(p,'textEmbedding', textEmbedding)
 RETURN p.productID, p.text, p.textEmbedding;
-//
-
-// IF USING AzureOpenAI
-MATCH(p:Product)-[:BELONGS_TO]-(c:Category)
-SET p.text = "Product Category: " + c.categoryName + ' - ' + c.description + "\nProduct Name: " + p.productName
-WITH p, genai.vector.encode(p.text, token: $provider, {$openAIKey, resource: $resource, deployment: $deployment}) AS textEmbedding
-CALL db.create.setNodeVectorProperty(p,'textEmbedding', textEmbedding)
-RETURN p.productID, p.text, p.textEmbedding;
-//
 
 //create vector index
 CREATE VECTOR INDEX product_text_embeddings


### PR DESCRIPTION
The updated northwind-data has the Cypher if you are using AzureOpenAI instead of the OpenAI endpoint. This is particularly useful when you cannot acccess OpenAI directly due to restrictions in your organisation but you have an AzureOpenAI deployment endpoint ready.